### PR TITLE
v1.1.1 — Fixed whitespace in rules which was causing error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.1.1
+------------------------------
+*July 8 2019*
+
+### Fixed
+ - Fixed whitespace in rules which was causing error.
+
+
 v1.1.0
 ------------------------------
 *July 5 2019*
 
+### Changed
  - Updating Browserlist config to be more in line with our browser support (removing some weird browsers due to the 'last 2 browsers' rule)
 
 
@@ -15,4 +24,5 @@ v1.0.0
 ------------------------------
 *July 5 2019*
 
+### Added
  - Base setup of shareable browserslist config.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 module.exports = [
-    '>= 1 % in GB',
+    '>= 1% in GB',
     'ie 11',
     'last 3 Chrome versions',
     'last 2 Firefox versions',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/browserslist-config-fozzie",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Just Eat's Browserslist config used in UI packages",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Fixed
 - Fixed whitespace in rules which was causing error.