### PR TITLE
v1.3.0 - Remove IE from browserslist and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v1.3.0
+------------------------------
+*July 27 2022*
+
+### Changed
+- Remove IE 11 from the supported browsers list.
+
+
 v1.2.0
 ------------------------------
 *November 3 2020*

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 module.exports = [
     '>= 1% in GB',
-    'ie 11',
     'last 3 Chrome versions',
     'last 2 Firefox versions',
     'last 2 Edge versions',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/browserslist-config-fozzie",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Just Eat's Browserslist config used in UI packages",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
v1.3.0
------------------------------
*July 27 2022*

### Changed
- Remove IE 11 from the supported browsers list.
